### PR TITLE
Remove auto initialisation

### DIFF
--- a/lib/aesop.rb
+++ b/lib/aesop.rb
@@ -22,6 +22,4 @@ elsif defined? Rails
     # We need it to add dev mode routes after initialization finished.
     Aesop::Aesop.instance.init
   end
-else
-  Aesop::Aesop.instance.init
 end

--- a/spec/aesop/aesop_spec.rb
+++ b/spec/aesop/aesop_spec.rb
@@ -1,6 +1,11 @@
 require File.join( File.dirname(__FILE__), '..', 'spec_helper')
 
 describe Aesop::Aesop do
+
+  before do
+    Aesop::Aesop.instance.init
+  end
+
   subject{ Aesop::Aesop.instance }
 
   context 'configuration' do

--- a/spec/aesop/hooks_spec.rb
+++ b/spec/aesop/hooks_spec.rb
@@ -71,8 +71,8 @@ describe 'Creating Hooks' do
   end
 
   context 'Other' do
-    it 'inits' do
-      Aesop::Aesop.instance.should_receive(:init)
+    it 'does not init' do
+      expect(Aesop::Aesop.instance).to_not receive(:init)
       load_file
     end
   end


### PR DESCRIPTION
Currently, not running Redis and executing `require 'aesop'` from a IRB shell results in a `Aesop::RedisConnectionException`. One should be able to require the gem, set some configuration options, and then manually call the initialisation method.
